### PR TITLE
Fix multi-floor building shadows (_Outdoors resolution + lighting roof-cutout)

### DIFF
--- a/scripts/compositor-v2/effects/BuildingShadowsEffectV2.js
+++ b/scripts/compositor-v2/effects/BuildingShadowsEffectV2.js
@@ -978,26 +978,46 @@ export class BuildingShadowsEffectV2 {
   }
 
   _resolveReceiverMaskTexture(compositor) {
+    if (!compositor) return this._outdoorsMask ?? null;
+
+    const floorStackFloors = window.MapShine?.floorStack?.getFloors?.() ?? [];
+    const activeFloorForMask = window.MapShine?.floorStack?.getActiveFloor?.() ?? null;
+    const activeIdxForMask = Number(activeFloorForMask?.index);
+    const skipGroundGlobalFallback = floorStackFloors.length > 1
+      && Number.isFinite(activeIdxForMask)
+      && activeIdxForMask > 0;
+
+    const r = resolveCompositorOutdoorsTexture(
+      compositor,
+      window.MapShine?.activeLevelContext ?? null,
+      { skipGroundFallback: skipGroundGlobalFallback, allowBundleFallback: false },
+    );
+    if (r.texture) return r.texture;
+
+    // Fractional activeLevelContext vs integer compositor keys (same as FloorCompositor fire path).
     const ctx = window.MapShine?.activeLevelContext ?? null;
-    const activeKey = (ctx && Number.isFinite(Number(ctx.bottom)) && Number.isFinite(Number(ctx.top)))
-      ? `${ctx.bottom}:${ctx.top}`
-      : null;
-
-    if (activeKey) {
-      const tex = compositor.getFloorTexture(activeKey, 'outdoors');
-      if (tex) return tex;
-    }
-
-    const activeFloor = window.MapShine?.floorStack?.getActiveFloor?.() ?? null;
-    if (activeFloor) {
-      if (activeFloor.compositorKey) {
-        const texCk = compositor.getFloorTexture(String(activeFloor.compositorKey), 'outdoors');
-        if (texCk) return texCk;
+    const b = Number(ctx?.bottom);
+    const t = Number(ctx?.top);
+    if (Number.isFinite(b) && Number.isFinite(t) && compositor._floorCache) {
+      const mid = (b + t) * 0.5;
+      const cacheKeys = Array.from(compositor._floorCache.keys?.() ?? []);
+      let bestKey = null;
+      let bestDelta = Infinity;
+      for (const key of cacheKeys) {
+        const parts = String(key).split(':');
+        if (parts.length !== 2) continue;
+        const kb = Number(parts[0]);
+        const kt = Number(parts[1]);
+        if (!Number.isFinite(kb) || !Number.isFinite(kt)) continue;
+        if (mid < kb || mid > kt) continue;
+        const delta = Math.abs(kb - b) + Math.abs(kt - t);
+        if (delta < bestDelta) {
+          bestDelta = delta;
+          bestKey = key;
+        }
       }
-      const b = Number(activeFloor?.elevationMin);
-      const t = Number(activeFloor?.elevationMax);
-      if (Number.isFinite(b) && Number.isFinite(t)) {
-        const tex = compositor.getFloorTexture(`${b}:${t}`, 'outdoors');
+      if (bestKey) {
+        const tex = compositor.getFloorTexture(bestKey, 'outdoors');
         if (tex) return tex;
       }
     }

--- a/scripts/compositor-v2/effects/LightingEffectV2.js
+++ b/scripts/compositor-v2/effects/LightingEffectV2.js
@@ -313,7 +313,7 @@ export class LightingEffectV2 {
           type: 'boolean',
           default: true,
           label: 'Multi-floor: roof gate & building roof-cutout top floor only',
-          tooltip: 'When on (recommended for 2+ floors), Foundry lights and building-shadow roof suppression use screen-space roof alpha only on the top floor — prevents upper-floor silhouettes from cutting lower-floor shadows and lights. Turn off for legacy “always gate” (single-floor maps are unaffected).',
+          tooltip: 'When on (recommended for 2+ floors), Foundry lights use screen-space roof alpha only on the top floor so upstairs stamps do not cut lower-floor lights. Building shadows skip roof-cutout on the uppermost band when 2+ floors exist (that band’s map art is often on the roof layer and would otherwise suppress all building shadows). Single-floor maps unchanged. Turn off for legacy “always gate” on lights.',
         },
         upperFloorTransmissionEnabled: { type: 'boolean', default: false, label: 'Upper Floor Through-Gaps' },
         upperFloorTransmissionStrength: { type: 'slider', min: 0, max: 2, step: 0.05, default: 0.6, label: 'Upper Light Strength' },
@@ -1153,7 +1153,17 @@ export class LightingEffectV2 {
       cu0.uApplyRoofOcclusionToSources.value = occlusionWeight * roofScreenOcclusionScale;
       // Window overlays: floor-isolated elsewhere; compose-level roof gating off (0f7b217).
       cu0.uApplyRoofOcclusionToWindow.value = 0.0;
-      cu0.uApplyRoofOcclusionToBuilding.value = roofScreenOcclusionScale;
+      // Building shadows are scene-UV; screen-space roof alpha still suppresses them where
+      // tOverheadRoofAlpha is high. On the *uppermost* band of a multi-floor map, the main
+      // level art often lives on ROOF_LAYER (tile over underground background) so the roof
+      // visibility pass covers the whole viewport and wipes building shadows entirely.
+      // Foundry light roof gating keeps using roofScreenOcclusionScale; building shadows rely
+      // on BuildingShadowsEffectV2's receiver _Outdoors gate instead for that case.
+      const onUppermostMultiFloor = persp.isMultiFloor
+        && persp.activeFloorIndex === persp.topFloorIndex
+        && persp.topFloorIndex > 0;
+      const buildingRoofOcclusionScale = onUppermostMultiFloor ? 0.0 : roofScreenOcclusionScale;
+      cu0.uApplyRoofOcclusionToBuilding.value = buildingRoofOcclusionScale;
     } catch (_) {
       const cu0 = this._composeMaterial.uniforms;
       cu0.uApplyRoofOcclusionToSources.value = 1.0;

--- a/scripts/masks/resolve-compositor-outdoors.js
+++ b/scripts/masks/resolve-compositor-outdoors.js
@@ -2,8 +2,14 @@
  * Unified GpuSceneMaskCompositor _Outdoors resolution for FloorCompositor,
  * BuildingShadowsEffectV2, and diagnostics.
  *
- * Order: active level band key → active floor compositorKey → compositor._activeFloorKey,
- * then sibling keys (same band bottom in _floorMeta / _floorCache), then ground band.
+ * Order: **FloorStack active floor** (compositorKey + elevation band) → active level band key
+ * → compositor._activeFloorKey, then sibling keys (same band bottom in _floorMeta / _floorCache),
+ * then ground band.
+ *
+ * Rationale: GpuSceneMaskCompositor keys masks by rendered floor bands. `activeLevelContext`
+ * (CameraFollower) can briefly disagree with `floorStack` (e.g. scene-background vs upper
+ * tile floor). Trying level context first caused wrong-band _Outdoors (e.g. all-indoor
+ * underground) to win over the viewed floor's mask for BuildingShadowsEffectV2 and sync.
  *
  * @module masks/resolve-compositor-outdoors
  */
@@ -29,16 +35,20 @@ export function resolveCompositorOutdoorsTexture(compositor, levelContext = null
   };
 
   const candidateKeys = [];
-  const cb = Number(ctx?.bottom);
-  const ct = Number(ctx?.top);
-  if (Number.isFinite(cb) && Number.isFinite(ct)) candidateKeys.push(`${cb}:${ct}`);
 
   let activeFloor = null;
   try {
     activeFloor = window.MapShine?.floorStack?.getActiveFloor?.() ?? null;
     const ck = activeFloor?.compositorKey;
     if (ck) candidateKeys.push(String(ck));
+    const eb = Number(activeFloor?.elevationMin);
+    const et = Number(activeFloor?.elevationMax);
+    if (Number.isFinite(eb) && Number.isFinite(et)) candidateKeys.push(`${eb}:${et}`);
   } catch (_) {}
+
+  const cb = Number(ctx?.bottom);
+  const ct = Number(ctx?.top);
+  if (Number.isFinite(cb) && Number.isFinite(ct)) candidateKeys.push(`${cb}:${ct}`);
 
   const cak = compositor._activeFloorKey ?? null;
   if (cak) candidateKeys.push(String(cak));
@@ -49,8 +59,11 @@ export function resolveCompositorOutdoorsTexture(compositor, levelContext = null
     if (tex) return { texture: tex, resolvedKey: key, route: 'direct' };
   }
 
-  const bottom = Number.isFinite(cb) ? cb : Number(activeFloor?.elevationMin);
-  if (Number.isFinite(bottom)) {
+  // Prefer rendered floor band bottom (floor stack) so sibling scan matches the viewed band.
+  const siblingBottom = Number.isFinite(Number(activeFloor?.elevationMin))
+    ? Number(activeFloor.elevationMin)
+    : (Number.isFinite(cb) ? cb : Number.NaN);
+  if (Number.isFinite(siblingBottom)) {
     /** @type {Set<string>} */
     const keySet = new Set();
     try {
@@ -63,7 +76,7 @@ export function resolveCompositorOutdoorsTexture(compositor, levelContext = null
         for (const k of compositor._floorCache.keys()) keySet.add(String(k));
       }
     } catch (_) {}
-    const matching = [...keySet].filter((key) => Number(String(key).split(':')[0]) === bottom).sort();
+    const matching = [...keySet].filter((key) => Number(String(key).split(':')[0]) === siblingBottom).sort();
     for (const key of matching) {
       if (uniqueKeys.includes(key)) continue;
       tex = tryKey(key);


### PR DESCRIPTION
## Summary
- Prefer **FloorStack** active band over **activeLevelContext** when resolving GpuSceneMaskCompositor \_Outdoors\ keys (\esolve-compositor-outdoors.js\), including sibling-key scan.
- **BuildingShadowsEffectV2**: resolve receiver mask via unified resolver + fractional band fallback; align skip-ground behavior with FloorCompositor on upper multi-floor bands.
- **LightingEffectV2**: disable screen-space roof alpha cutout for building shadows on the **uppermost** band when **2+ floors** exist, so full-viewport roof-layer map art does not erase building shadows (lights still use existing roof gating).

## Test plan
- [ ] Big Bank (or similar): two bands — scene background + tile upper; confirm building shadows visible on upper band.
- [ ] Single-floor map: unchanged roof/building shadow behavior.
- [ ] Multi-floor lower band: lights/shadows still not cut by upstairs roof stamp.