### PR TITLE
Multi-floor building shadows (outdoors/roof) and mask pipeline updates

### DIFF
--- a/scripts/assets/loader.js
+++ b/scripts/assets/loader.js
@@ -232,14 +232,18 @@ function _buildExtensionVariants(preferredExt) {
   return out;
 }
 
+/**
+ * @param {'minimal'|'full'} [options.probeMode='minimal'] — minimal: basePath + canonical suffix +
+ *   (source extension, then webp). full: legacy cartesian product of path/suffix/extension variants
+ *   (very noisy on 404; diagnostics / explicit opt-in only).
+ */
 export function buildMaskManifest(basePath, options = {}) {
   const src = String(basePath || '').trim();
   if (!src) return {};
+  const probeMode = options.probeMode === 'full' ? 'full' : 'minimal';
   const ext = String(options?.extension || _extractExtension(canvas?.scene?.background?.src) || 'webp')
     .toLowerCase()
     .replace(/^\./, '');
-  const baseVariants = _buildBasePathVariants(src);
-  const extVariants = _buildExtensionVariants(ext);
   const requestedMaskIds = (() => {
     if (!Array.isArray(options?.maskIds) || options.maskIds.length === 0) return null;
     return new Set(options.maskIds.map((v) => String(v || '').toLowerCase()).filter(Boolean));
@@ -248,17 +252,31 @@ export function buildMaskManifest(basePath, options = {}) {
   for (const [maskId, def] of Object.entries(EFFECT_MASKS)) {
     if (!def?.suffix) continue;
     if (requestedMaskIds && !requestedMaskIds.has(String(maskId).toLowerCase())) continue;
-    const suffixVariants = _buildSuffixVariants(def.suffix);
-    const candidates = [];
-    for (const b of baseVariants) {
-      for (const s of suffixVariants) {
-        for (const e of extVariants) {
-          const c = normalizePath(`${b}${s}.${e}`);
-          if (!candidates.includes(c)) candidates.push(c);
+
+    if (probeMode === 'full') {
+      const baseVariants = _buildBasePathVariants(src);
+      const extVariants = _buildExtensionVariants(ext);
+      const suffixVariants = _buildSuffixVariants(def.suffix);
+      const candidates = [];
+      for (const b of baseVariants) {
+        for (const s of suffixVariants) {
+          for (const e of extVariants) {
+            const c = normalizePath(`${b}${s}.${e}`);
+            if (!candidates.includes(c)) candidates.push(c);
+          }
         }
       }
+      manifest[def.suffix] = candidates;
+    } else {
+      const candidates = [];
+      const push = (rel) => {
+        const c = normalizePath(rel);
+        if (!candidates.includes(c)) candidates.push(c);
+      };
+      push(`${src}${def.suffix}.${ext}`);
+      if (ext !== 'webp') push(`${src}${def.suffix}.webp`);
+      manifest[def.suffix] = candidates;
     }
-    manifest[def.suffix] = candidates;
   }
   return manifest;
 }
@@ -296,8 +314,18 @@ export async function loadAssetBundle(basePath, onProgress = null, options = {})
     maskManifest = null,
     maskExtension = null,
     maskIds = null,
-    cacheKeySuffix = ''
+    cacheKeySuffix = '',
+    /**
+     * off: only load masks listed in maskManifest (no URL guessing; for players without a scene flag).
+     * minimal (default): at most two candidate URLs per mask (source ext + webp fallback).
+     * full: legacy high-cardinality probing (diagnostics / explicit opt-in only).
+     */
+    maskConventionFallback = 'minimal'
   } = options || {};
+
+  const convFallback =
+    maskConventionFallback === 'off' ? 'off' : maskConventionFallback === 'full' ? 'full' : 'minimal';
+  const probeMode = convFallback === 'full' ? 'full' : 'minimal';
 
   log.info(`Loading asset bundle: ${basePath}${skipBaseTexture ? ' (masks only)' : ''}`);
 
@@ -430,31 +458,34 @@ export async function loadAssetBundle(basePath, onProgress = null, options = {})
     // optional-but-important masks like _Outdoors are still attempted.
     const baseManifest = (maskManifest && typeof maskManifest === 'object')
       ? maskManifest
-      : buildMaskManifest(basePath, { extension: maskExtension, maskIds });
+      : buildMaskManifest(basePath, { extension: maskExtension, maskIds, probeMode });
     const effectiveManifest = { ...(baseManifest || {}) };
-    try {
-      const requestedMaskIds = Array.isArray(maskIds) && maskIds.length > 0
-        ? maskIds.map((v) => String(v || '').toLowerCase()).filter(Boolean)
-        : Object.keys(EFFECT_MASKS);
-      const fallbackManifest = buildMaskManifest(basePath, {
-        extension: maskExtension,
-        maskIds: requestedMaskIds,
-      });
-      for (const [maskId, def] of Object.entries(EFFECT_MASKS)) {
-        const idLower = String(maskId || '').toLowerCase();
-        if (!requestedMaskIds.includes(idLower)) continue;
-        const suffix = def?.suffix;
-        if (!suffix) continue;
-        const hasExisting = Array.isArray(effectiveManifest[suffix])
-          ? effectiveManifest[suffix].length > 0
-          : (typeof effectiveManifest[suffix] === 'string' && !!effectiveManifest[suffix].trim());
-        if (hasExisting) continue;
-        const fallbackCandidates = fallbackManifest?.[suffix];
-        if (Array.isArray(fallbackCandidates) && fallbackCandidates.length > 0) {
-          effectiveManifest[suffix] = fallbackCandidates;
+    if (convFallback !== 'off') {
+      try {
+        const requestedMaskIds = Array.isArray(maskIds) && maskIds.length > 0
+          ? maskIds.map((v) => String(v || '').toLowerCase()).filter(Boolean)
+          : Object.keys(EFFECT_MASKS);
+        const fallbackManifest = buildMaskManifest(basePath, {
+          extension: maskExtension,
+          maskIds: requestedMaskIds,
+          probeMode,
+        });
+        for (const [maskId, def] of Object.entries(EFFECT_MASKS)) {
+          const idLower = String(maskId || '').toLowerCase();
+          if (!requestedMaskIds.includes(idLower)) continue;
+          const suffix = def?.suffix;
+          if (!suffix) continue;
+          const hasExisting = Array.isArray(effectiveManifest[suffix])
+            ? effectiveManifest[suffix].length > 0
+            : (typeof effectiveManifest[suffix] === 'string' && !!effectiveManifest[suffix].trim());
+          if (hasExisting) continue;
+          const fallbackCandidates = fallbackManifest?.[suffix];
+          if (Array.isArray(fallbackCandidates) && fallbackCandidates.length > 0) {
+            effectiveManifest[suffix] = fallbackCandidates;
+          }
         }
-      }
-    } catch (_) {}
+      } catch (_) {}
+    }
 
     // Step 3: Load masks in parallel with concurrency limit
     const semaphore = new Semaphore(4);
@@ -993,7 +1024,16 @@ function _pathFromSceneMaskTextureManifest(scene, basePath, suffix) {
  * @returns {Promise<string|null>}
  */
 async function _probeMaskPathByConvention(basePath, suffix) {
-  for (const format of SUPPORTED_FORMATS) {
+  const preferred =
+    _extractExtension(typeof canvas !== 'undefined' ? canvas?.scene?.background?.src : '') || 'webp';
+  const formats = [];
+  const pushFmt = (f) => {
+    const s = String(f || '').toLowerCase().replace(/^\./, '');
+    if (s && !formats.includes(s)) formats.push(s);
+  };
+  pushFmt(preferred);
+  if (preferred !== 'webp') pushFmt('webp');
+  for (const format of formats) {
     const candidate = `${basePath}${suffix}.${format}`;
     const u = normalizePath(candidate);
     try {

--- a/scripts/compositor-v2/FloorRenderBus.js
+++ b/scripts/compositor-v2/FloorRenderBus.js
@@ -514,6 +514,9 @@ export class FloorRenderBus {
       if (!entry?.material) continue;
       // Skip internal background/effect entries.
       if (tileId.startsWith('__')) continue;
+      // Tree/Bush V2 shaders output premultiplied RGB + manage their own fringes; do not
+      // force floor-based premultipliedAlpha (would break ground-floor blending).
+      if (tileId.endsWith('_tree') || tileId.endsWith('_bush')) continue;
 
       const sourceTileId = entry.attachedToTileId || tileId;
       const data = tileManager.getTileSpriteData(sourceTileId);
@@ -714,6 +717,7 @@ export class FloorRenderBus {
     for (const [tileId, entry] of this._tiles) {
       if (!entry?.material) continue;
       if (tileId.startsWith('__')) continue;
+      if (tileId.endsWith('_tree') || tileId.endsWith('_bush')) continue;
 
       const sourceTileId = entry.attachedToTileId || tileId;
       const data = tileManager.getTileSpriteData(sourceTileId);

--- a/scripts/compositor-v2/effects/BuildingShadowsEffectV2.js
+++ b/scripts/compositor-v2/effects/BuildingShadowsEffectV2.js
@@ -558,6 +558,24 @@ export class BuildingShadowsEffectV2 {
     this._sunElevationDeg = Number(elevationDeg);
   }
 
+  /**
+   * Align with {@link FloorCompositor#_resolveOutdoorsMask}: never use lowest-band ground
+   * (or scene background bundle) as a stand-in _Outdoors source while viewing an upper
+   * floor in a multi-floor stack — that masks the real upper-band mask and kills shadows.
+   * @returns {boolean}
+   */
+  _skipGroundAndBundleFallbackForUpperMultiFloor() {
+    let floorStackFloors = [];
+    try {
+      floorStackFloors = window.MapShine?.floorStack?.getFloors?.() ?? [];
+    } catch (_) {
+      floorStackFloors = [];
+    }
+    const af = window.MapShine?.floorStack?.getActiveFloor?.() ?? null;
+    const idx = Number(af?.index);
+    return floorStackFloors.length > 1 && Number.isFinite(idx) && idx > 0;
+  }
+
   render(renderer, camera) {
     if (camera) this.mainCamera = camera;
     if (!renderer || !this._projectMaterial || !this._invertMaterial || !this._scene || !this._quad || !this.shadowTarget || !this._strengthTarget) {
@@ -590,10 +608,14 @@ export class BuildingShadowsEffectV2 {
       return;
     }
 
+    const strictUpper = this._skipGroundAndBundleFallbackForUpperMultiFloor();
     const outdoorResolve = resolveCompositorOutdoorsTexture(
       compositor,
       window.MapShine?.activeLevelContext ?? null,
-      { skipGroundFallback: false, allowBundleFallback: true },
+      {
+        skipGroundFallback: strictUpper,
+        allowBundleFallback: !strictUpper,
+      },
     );
 
     const floorCount = Number(window.MapShine?.floorStack?.getFloors?.()?.length ?? 0);
@@ -872,6 +894,10 @@ export class BuildingShadowsEffectV2 {
       resolvedActiveIdx = 0;
     }
 
+    const skipGroundGlobalFallback = floors.length > 1
+      && Number.isFinite(resolvedActiveIdx)
+      && resolvedActiveIdx > 0;
+
     if (Array.isArray(floors) && floors.length > 0) {
       for (const floor of floors) {
         if (!Number.isFinite(floor?.index) || floor.index < resolvedActiveIdx) continue;
@@ -923,13 +949,17 @@ export class BuildingShadowsEffectV2 {
       pushKey('ground');
     }
 
-    // Unified resolver: if stack/context keys missed but a sibling or ground
-    // texture exists, use that key so the projection pass matches FloorCompositor sync.
+    // Unified resolver: sibling / extra keys only — never ground (or background bundle)
+    // on upper multi-floor; that yields floorKeys ["0:20"] while active is 20:30 and
+    // wipes correct upper-band building shadows until GPU meta repopulates.
     if (keys.length === 0 && compositor) {
       const r = resolveCompositorOutdoorsTexture(
         compositor,
         window.MapShine?.activeLevelContext ?? null,
-        { skipGroundFallback: false },
+        {
+          skipGroundFallback: skipGroundGlobalFallback,
+          allowBundleFallback: !skipGroundGlobalFallback,
+        },
       );
       if (r.resolvedKey && r.texture) {
         pushKey(r.resolvedKey);
@@ -969,10 +999,14 @@ export class BuildingShadowsEffectV2 {
    */
   _resolveCompositorOutdoorsDirect(compositor) {
     if (!compositor) return null;
+    const strictUpper = this._skipGroundAndBundleFallbackForUpperMultiFloor();
     const r = resolveCompositorOutdoorsTexture(
       compositor,
       window.MapShine?.activeLevelContext ?? null,
-      { skipGroundFallback: false },
+      {
+        skipGroundFallback: strictUpper,
+        allowBundleFallback: !strictUpper,
+      },
     );
     return r.texture ?? null;
   }
@@ -994,16 +1028,24 @@ export class BuildingShadowsEffectV2 {
     );
     if (r.texture) return r.texture;
 
-    // Fractional activeLevelContext vs integer compositor keys (same as FloorCompositor fire path).
+    // Fractional band vs integer compositor keys (FloorCompositor fire path). Include
+    // _floorMeta keys — _floorCache can be empty while file/bundle masks live in meta only.
     const ctx = window.MapShine?.activeLevelContext ?? null;
-    const b = Number(ctx?.bottom);
-    const t = Number(ctx?.top);
-    if (Number.isFinite(b) && Number.isFinite(t) && compositor._floorCache) {
+    const b = Number.isFinite(Number(activeFloorForMask?.elevationMin))
+      ? Number(activeFloorForMask.elevationMin)
+      : Number(ctx?.bottom);
+    const t = Number.isFinite(Number(activeFloorForMask?.elevationMax))
+      ? Number(activeFloorForMask.elevationMax)
+      : Number(ctx?.top);
+    if (Number.isFinite(b) && Number.isFinite(t)) {
       const mid = (b + t) * 0.5;
-      const cacheKeys = Array.from(compositor._floorCache.keys?.() ?? []);
+      const keySet = new Set([
+        ...Array.from(compositor._floorCache?.keys?.() ?? []),
+        ...Array.from(compositor._floorMeta?.keys?.() ?? []),
+      ]);
       let bestKey = null;
       let bestDelta = Infinity;
-      for (const key of cacheKeys) {
+      for (const key of keySet) {
         const parts = String(key).split(':');
         if (parts.length !== 2) continue;
         const kb = Number(parts[0]);

--- a/scripts/compositor-v2/effects/BushEffectV2.js
+++ b/scripts/compositor-v2/effects/BushEffectV2.js
@@ -751,20 +751,22 @@ export class BushEffectV2 {
           shadowA *= clamp(uShadowOpacity, 0.0, 1.0) * uIntensity * edgeFade;
 
           vec4 bushSample = texture2D(uBushMask, vUv - distortion);
-          float mainAlpha = safeAlpha(bushSample) * uIntensity;
+          float texA = safeAlpha(bushSample);
+          float mainAlpha = texA * uIntensity;
           float shadowOnlyAlpha = shadowA * (1.0 - clamp(mainAlpha, 0.0, 1.0));
           float finalAlpha = clamp(mainAlpha + shadowOnlyAlpha, 0.0, 1.0);
           if (finalAlpha <= 0.001) discard;
 
           float ccDelta = abs(uExposure) + abs(uBrightness) + abs(uContrast - 1.0)
                         + abs(uSaturation - 1.0) + abs(uTemperature) + abs(uTint);
-          vec3 color = bushSample.rgb;
-          if (ccDelta > 0.0001) color = applyCC(color);
-          vec3 finalColor = mix(vec3(0.0), color, mainAlpha / max(finalAlpha, 1e-4));
-          gl_FragColor = vec4(finalColor, finalAlpha);
+          vec3 c = bushSample.rgb;
+          if (ccDelta > 0.0001) c = applyCC(c);
+          c *= texA;
+          gl_FragColor = vec4(c * uIntensity, finalAlpha);
         }
       `,
       transparent: true,
+      premultipliedAlpha: true,
       depthWrite: false,
       depthTest: false,
       side: THREE.DoubleSide,

--- a/scripts/compositor-v2/effects/TreeEffectV2.js
+++ b/scripts/compositor-v2/effects/TreeEffectV2.js
@@ -972,8 +972,8 @@ export class TreeEffectV2 {
           shadowA *= clamp(uShadowOpacity, 0.0, 1.0) * uIntensity * edgeFade * clamp(uHoverFade, 0.0, 1.0);
 
           vec4 treeSample = texture2D(uTreeMask, vUv - distortion);
-
-          float mainAlpha = safeAlpha(treeSample) * uIntensity * clamp(uHoverFade, 0.0, 1.0);
+          float texA = safeAlpha(treeSample);
+          float mainAlpha = texA * uIntensity * clamp(uHoverFade, 0.0, 1.0);
           // Prevent soft shadow bloom from extending beyond canopy edges.
           // Gate shadow contribution by local canopy coverage.
           float canopyGate = smoothstep(0.03, 0.35, clamp(mainAlpha, 0.0, 1.0));
@@ -983,13 +983,17 @@ export class TreeEffectV2 {
 
           float ccDelta = abs(uExposure) + abs(uBrightness) + abs(uContrast - 1.0)
                         + abs(uSaturation - 1.0) + abs(uTemperature) + abs(uTint);
-          vec3 color = treeSample.rgb;
-          if (ccDelta > 0.0001) color = applyCC(color);
-          vec3 finalColor = mix(vec3(0.0), color, mainAlpha / max(a, 1e-4));
-          gl_FragColor = vec4(finalColor, clamp(a, 0.0, 1.0));
+          vec3 c = treeSample.rgb;
+          if (ccDelta > 0.0001) c = applyCC(c);
+          // Kill white fringe: filtering blends RGB from empty/white texels while alpha
+          // drops; scaling by coverage makes premultiplied output match the mask energy.
+          c *= texA;
+          float ih = uIntensity * clamp(uHoverFade, 0.0, 1.0);
+          gl_FragColor = vec4(c * ih, clamp(a, 0.0, 1.0));
         }
       `,
       transparent: true,
+      premultipliedAlpha: true,
       depthWrite: false,
       depthTest: false,
       side: THREE.DoubleSide,

--- a/scripts/masks/GpuSceneMaskCompositor.js
+++ b/scripts/masks/GpuSceneMaskCompositor.js
@@ -38,6 +38,8 @@ function loadAssetBundleOptsFromScene(scene, basePath) {
     maskIds: o.maskIds,
     cacheKeySuffix: o.cacheKeySuffix,
     skipMaskIds: o.skipMaskIds,
+    maskExtension: o.maskExtension,
+    maskConventionFallback: o.maskConventionFallback,
   };
 }
 
@@ -342,6 +344,13 @@ export class GpuSceneMaskCompositor {
      * @type {Set<string>}
      */
     this._singleBandPreloadDone = new Set();
+
+    /**
+     * Bounded composeFloor cache invalidations when an upper band has tiles but
+     * getFloorTexture(_, 'outdoors') is null (stale _floorMeta from early preload).
+     * @type {Map<string, number>}
+     */
+    this._upperOutdoorsMetaRepairCount = new Map();
 
     /** @type {Promise<void>|null} Serialize concurrent preloadAllFloors (load + effects). */
     this._preloadAllFloorsInFlight = null;
@@ -658,7 +667,24 @@ export class GpuSceneMaskCompositor {
     const levelElevation = bandBottom;
 
     // Fast path: floor already composited — return cached metadata.
-    const cached = this._floorMeta.get(floorKey);
+    let cached = this._floorMeta.get(floorKey);
+    if (cached?.masks?.length) {
+      const needsUpperOutdoorsRepair =
+        bandBottom > 0
+        && !this.getFloorTexture(floorKey, 'outdoors')
+        && this._getActiveLevelTiles(sc, ctx).length > 0;
+      if (needsUpperOutdoorsRepair) {
+        const n = (this._upperOutdoorsMetaRepairCount.get(floorKey) ?? 0) + 1;
+        if (n <= 2) {
+          this._upperOutdoorsMetaRepairCount.set(floorKey, n);
+          log.info('composeFloor: evicting stale upper-floor meta without outdoors texture', { floorKey, attempt: n });
+          this._floorMeta.delete(floorKey);
+          cached = null;
+        }
+      } else if (bandBottom > 0 && this.getFloorTexture(floorKey, 'outdoors')) {
+        this._upperOutdoorsMetaRepairCount.delete(floorKey);
+      }
+    }
     if (cached?.masks?.length) {
       // Pass cached masks through directly. The compositor's _readbackIsNonEmpty
       // check already strips empty masks (black-RGB floor-boundary alphas), so
@@ -854,7 +880,10 @@ export class GpuSceneMaskCompositor {
 
     // Store in per-floor metadata cache.
     this._floorMeta.set(floorKey, { masks: newMasks, basePath: primaryBasePath });
-    
+    if (bandBottom > 0 && this.getFloorTexture(floorKey, 'outdoors')) {
+      this._upperOutdoorsMetaRepairCount.delete(floorKey);
+    }
+
     // Single diagnostic log per floor composition - show what masks we have
     const outdoorsEntry = newMasks.find(m => (m?.id || m?.type) === 'outdoors');
     log.info(`composeFloor[${floorKey}]: stored ${newMasks.length} masks, outdoors=${outdoorsEntry ? (outdoorsEntry.texture ? 'texture' : 'no-texture') : 'missing'}`);
@@ -1089,7 +1118,17 @@ export class GpuSceneMaskCompositor {
         } catch (_clearErr) {}
 
         // Skip if the band is already correctly cached (nothing was evicted above).
-        if (this._floorMeta.has(bandKey)) continue;
+        if (this._floorMeta.has(bandKey)) {
+          const bBot = Number(bottom);
+          const lacksOutdoors = !this.getFloorTexture(bandKey, 'outdoors');
+          const hasTiles = this._getActiveLevelTiles(sc, { bottom, top }).length > 0;
+          if (Number.isFinite(bBot) && bBot > 0 && lacksOutdoors && hasTiles) {
+            log.info('preloadAllFloors: evicting upper band meta without outdoors', { bandKey });
+            this._floorMeta.delete(bandKey);
+          } else {
+            continue;
+          }
+        }
 
         // For ground-floor bands, prefer the scene background image's basePath
         // so step 4 in composeFloor loads the correct masks, not an upper floor's.
@@ -1599,6 +1638,7 @@ export class GpuSceneMaskCompositor {
     this._floorMeta.clear();
     this._nonGmStaleRepairAttempted.clear();
     this._singleBandPreloadDone.clear();
+    this._upperOutdoorsMetaRepairCount.clear();
     this._preloadAllFloorsInFlight = null;
 
     // Dispose and clear cached GPU render targets. Floor keys (e.g. "0:5")
@@ -1723,6 +1763,7 @@ export class GpuSceneMaskCompositor {
     this._floorMeta.clear();
     this._nonGmStaleRepairAttempted.clear();
     this._singleBandPreloadDone.clear();
+    this._upperOutdoorsMetaRepairCount.clear();
     this._preloadAllFloorsInFlight = null;
     this._activeFloorBasePath = null;
     this._activeFloorKey = null;

--- a/scripts/scene/composer.js
+++ b/scripts/scene/composer.js
@@ -122,6 +122,8 @@ export class SceneComposer {
           maskIds: fromFlag.maskIds,
           cacheKeySuffix: fromFlag.cacheKeySuffix,
           skipMaskIds: fromFlag.skipMaskIds,
+          maskExtension: fromFlag.maskExtension,
+          maskConventionFallback: fromFlag.maskConventionFallback,
         };
       }
       const res = await assetLoader.loadAssetBundle(basePath, null, loadOpts);
@@ -578,6 +580,7 @@ export class SceneComposer {
             maskExtension: prepManifest.maskExtension,
             maskIds: enabledMaskIds,
             cacheKeySuffix: prepManifest.cacheKeySuffix,
+            maskConventionFallback: prepManifest.maskConventionFallback,
           }
         );
       } finally {

--- a/scripts/scene/tile-manager.js
+++ b/scripts/scene/tile-manager.js
@@ -14,7 +14,7 @@ import { debugLoadingProfiler } from '../core/debug-loading-profiler.js';
 import { isTileVisibleForPerspective, isBackgroundVisibleForPerspective, isWeatherVisibleForPerspective } from '../foundry/elevation-context.js';
 import { tileHasLevelsRange, isLevelsEnabledForScene, readTileLevelsFlags } from '../foundry/levels-scene-flags.js';
 import { applyTileLevelDefaults } from '../foundry/levels-create-defaults.js';
-import { getEffectMaskRegistry } from '../assets/loader.js';
+import { getEffectMaskRegistry, probeMaskFile } from '../assets/loader.js';
 import { getTextureBudgetTracker, estimateTextureBytes } from '../assets/TextureBudgetTracker.js';
 import { TileEffectBindingManager } from './TileEffectBindingManager.js';
 
@@ -810,20 +810,6 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
     return this._tileAllowsSpecular(tileDoc) && !this._tileBypassesEffects(tileDoc);
   }
 
-  _deriveMaskPath(src, suffix) {
-    const s = String(src || '');
-    if (!s) return null;
-    const q = s.indexOf('?');
-    const base = q >= 0 ? s.slice(0, q) : s;
-    const query = q >= 0 ? s.slice(q) : '';
-
-    const dot = base.lastIndexOf('.');
-    if (dot < 0) return null;
-    const path = base.slice(0, dot);
-    const ext = base.slice(dot);
-    return `${path}${suffix}${ext}${query}`;
-  }
-
   _splitUrl(src) {
     const s = String(src || '');
     if (!s) return null;
@@ -936,19 +922,26 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
   }
 
   /**
-   * Generic per-tile mask URL resolver. Probes for a given suffix mask
-   * alongside the tile's texture URL using the same FilePicker-based
-   * directory listing pattern as the existing Water/Specular/Fluid resolvers.
+   * Resolve a per-tile suffix mask path only when the file exists (FilePicker
+   * listing / shared probe cache). Avoids Foundry loadTexture() on missing
+   * optional masks — which logged Invalid Asset + 404 spam for every registry type.
    *
    * @param {object} tileDoc - Tile document (needs texture.src)
    * @param {string} suffix - Mask suffix (e.g. '_Fire', '_Outdoors')
-   * @returns {Promise<string|null>} Resolved URL or null if not found
+   * @returns {Promise<string|null>} Resolved path or null if not found
    * @private
    */
   async _resolveTileMaskUrl(tileDoc, suffix) {
     const src = tileDoc?.texture?.src;
     if (typeof src !== 'string' || !src.trim() || !suffix) return null;
-    return this._insertSuffixBeforeExtension(src.trim(), suffix);
+    const parts = this._splitUrl(src.trim());
+    if (!parts?.pathNoExt) return null;
+    try {
+      const hit = await probeMaskFile(parts.pathNoExt, suffix, { suppressProbeErrors: true });
+      return hit?.path ?? null;
+    } catch (_) {
+      return null;
+    }
   }
 
   /**
@@ -965,9 +958,15 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
     const tileId = tileDoc?.id;
     if (!tileId) return new Map();
 
-    // Return cached result if available.
+    // Return cached result if available and non-empty. An empty Map was stored when
+    // an early probe/load failed (timing, FilePicker) — GpuSceneMaskCompositor
+    // then skipped the tile forever ("EMPTY_MAP_poison"). Clear and re-probe.
     if (this._tileEffectMasks.has(tileId)) {
-      return this._tileEffectMasks.get(tileId);
+      const cached = this._tileEffectMasks.get(tileId);
+      if (cached instanceof Map && cached.size > 0) {
+        return cached;
+      }
+      this.clearTileEffectMasks(tileId);
     }
 
     // Budget guard: skip loading if per-tile effect mask VRAM exceeds budget.
@@ -1020,11 +1019,15 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
       }
 
       await Promise.all(promises);
-      this._tileEffectMasks.set(tileId, results);
 
-      // Track VRAM consumption for budget enforcement.
-      for (const entry of results.values()) {
-        this._tileEffectMaskVramBytes += this._estimateTextureBytes(entry?.texture);
+      // Do not cache an empty result: it poisons later compositor passes (tile
+      // skipped as "loaded" with zero masks). Tiles with no suffix files pay a
+      // re-probe on each composeFloor; that is rare and cheaper than a permanent miss.
+      if (results.size > 0) {
+        this._tileEffectMasks.set(tileId, results);
+        for (const entry of results.values()) {
+          this._tileEffectMaskVramBytes += this._estimateTextureBytes(entry?.texture);
+        }
       }
 
       return results;
@@ -1083,9 +1086,9 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
     }
 
     const p = (async () => {
-      const url = this._insertSuffixBeforeExtension(src, '_Water');
-      this._tileWaterMaskResolvedUrl.set(key, url || null);
-      return url || null;
+      const url = await this._resolveTileMaskUrl(tileDoc, '_Water');
+      this._tileWaterMaskResolvedUrl.set(key, url);
+      return url;
     })();
 
     this._tileWaterMaskResolvePromises.set(key, p);
@@ -1150,9 +1153,9 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
     }
 
     const p = (async () => {
-      const url = this._insertSuffixBeforeExtension(src, '_Specular');
-      this._tileSpecularMaskResolvedUrl.set(key, url || null);
-      return url || null;
+      const url = await this._resolveTileMaskUrl(tileDoc, '_Specular');
+      this._tileSpecularMaskResolvedUrl.set(key, url);
+      return url;
     })();
 
     this._tileSpecularMaskResolvePromises.set(key, p);
@@ -1214,9 +1217,9 @@ vec3 ms_applyOverheadColorCorrection(vec3 color) {
     }
 
     const p = (async () => {
-      const url = this._insertSuffixBeforeExtension(src, '_Fluid');
-      this._tileFluidMaskResolvedUrl.set(key, url || null);
-      return url || null;
+      const url = await this._resolveTileMaskUrl(tileDoc, '_Fluid');
+      this._tileFluidMaskResolvedUrl.set(key, url);
+      return url;
     })();
 
     this._tileFluidMaskResolvePromises.set(key, p);

--- a/scripts/settings/mask-manifest-flags.js
+++ b/scripts/settings/mask-manifest-flags.js
@@ -35,6 +35,14 @@ function _normBasePath(p) {
   return String(p || '').trim().replace(/\\/g, '/');
 }
 
+/** File extension from a texture URL (lowercase, no dot), or null */
+export function extensionFromTextureSrc(src) {
+  const s = String(src || '');
+  const noQuery = s.split('?')[0];
+  const dot = noQuery.lastIndexOf('.');
+  return dot >= 0 ? noQuery.slice(dot + 1).toLowerCase() : null;
+}
+
 /**
  * @param {Scene|null} scene
  * @returns {{ version?: number, basePath?: string, maskSourceKey?: string, pathsByMaskId?: Record<string, string>, updatedAt?: number } | null}
@@ -159,31 +167,22 @@ export async function persistMaskTextureManifest(scene, payload) {
  *
  * @param {Scene} scene
  * @param {{ basePath: string, maskSourceSrc: string, enabledMaskIds: string[] }} params
- * @returns {Promise<{ maskManifest: Record<string, string>, maskExtension: string|null, maskIds: string[], cacheKeySuffix: string }>}
+ * @returns {Promise<{ maskManifest: Record<string, string>, maskExtension: string|null, maskIds: string[], cacheKeySuffix: string, maskConventionFallback: 'off'|'minimal'|'full' }>}
  */
 export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSourceSrc, enabledMaskIds }) {
   if (typeof sceneSettings.isEnabled === 'function' && !sceneSettings.isEnabled(scene)) {
-    const ext = (() => {
-      const s = String(maskSourceSrc || '');
-      const noQuery = s.split('?')[0];
-      const dot = noQuery.lastIndexOf('.');
-      return dot >= 0 ? noQuery.slice(dot + 1).toLowerCase() : null;
-    })();
+    const ext = extensionFromTextureSrc(maskSourceSrc);
     return {
       maskManifest: {},
       maskExtension: ext,
       maskIds: enabledMaskIds,
       cacheKeySuffix: 'mf:disabled',
+      maskConventionFallback: 'off',
     };
   }
 
   const maskSourceKey = normalizeMaskSourceKey(maskSourceSrc || '');
-  const ext = (() => {
-    const s = String(maskSourceSrc || '');
-    const noQuery = s.split('?')[0];
-    const dot = noQuery.lastIndexOf('.');
-    return dot >= 0 ? noQuery.slice(dot + 1).toLowerCase() : null;
-  })();
+  const ext = extensionFromTextureSrc(maskSourceSrc);
 
   const flag = getMaskTextureManifest(scene);
   const flagMatches = maskTextureManifestMatchesBasePath(flag, basePath);
@@ -195,6 +194,8 @@ export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSou
       maskExtension: ext,
       maskIds: enabledMaskIds,
       cacheKeySuffix: `mf:${flag.updatedAt || 0}`,
+      // Paths came from GM directory listing — do not convention-probe missing optional masks (404 spam).
+      maskConventionFallback: 'off',
     };
   }
 
@@ -205,6 +206,7 @@ export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSou
       maskExtension: ext,
       maskIds: enabledMaskIds,
       cacheKeySuffix: 'mf:none',
+      maskConventionFallback: 'off',
     };
   }
 
@@ -223,6 +225,7 @@ export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSou
       maskExtension: ext,
       maskIds: enabledMaskIds,
       cacheKeySuffix: `mf:${Date.now()}`,
+      maskConventionFallback: available.length > 0 ? 'off' : 'minimal',
     };
   } catch (e) {
     log.warn('Mask directory discovery failed', e?.message ?? e);
@@ -233,6 +236,7 @@ export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSou
     maskExtension: ext,
     maskIds: enabledMaskIds,
     cacheKeySuffix: 'mf:none',
+    maskConventionFallback: 'minimal',
   };
 }
 
@@ -241,25 +245,28 @@ export async function prepareSceneMaskManifestForLoad(scene, { basePath, maskSou
  * @param {Scene} scene
  * @param {string} basePath
  * @param {string[]} enabledMaskIds
- * @returns {{ maskManifest: Record<string, string>, maskExtension: null, maskIds: string[], cacheKeySuffix: string, skipMaskIds?: string[] }}
+ * @returns {{ maskManifest: Record<string, string>, maskExtension: string|null, maskIds: string[], cacheKeySuffix: string, skipMaskIds?: string[], maskConventionFallback: 'off'|'minimal'|'full' }}
  */
 export function getMaskBundleOptionsFromFlagOnly(scene, basePath, enabledMaskIds, { skipMaskIds = ['water'] } = {}) {
+  const bgExt = extensionFromTextureSrc(scene?.background?.src);
   const flag = getMaskTextureManifest(scene);
   if (!maskTextureManifestMatchesBasePath(flag, basePath) || !flag.pathsByMaskId) {
     return {
       maskManifest: {},
-      maskExtension: null,
+      maskExtension: bgExt,
       maskIds: enabledMaskIds,
       cacheKeySuffix: 'mf:none',
       skipMaskIds,
+      maskConventionFallback: 'off',
     };
   }
   const manifest = pathsByMaskIdToLoaderManifest(flag.pathsByMaskId, enabledMaskIds);
   return {
     maskManifest: manifest,
-    maskExtension: null,
+    maskExtension: bgExt,
     maskIds: enabledMaskIds,
     cacheKeySuffix: `mf:${flag.updatedAt || 0}`,
     skipMaskIds,
+    maskConventionFallback: 'off',
   };
 }

--- a/scripts/ui/effect-stack.js
+++ b/scripts/ui/effect-stack.js
@@ -1,6 +1,11 @@
 import { isGmLike } from '../core/gm-parity.js';
 import { createLogger } from '../core/log.js';
-import { getEffectMaskRegistry, loadAssetBundle } from '../assets/loader.js';
+import {
+  getEffectMaskRegistry,
+  discoverMaskDirectoryFiles,
+  resolveMaskPathsFromListing,
+} from '../assets/loader.js';
+import { collectEnabledMaskIds } from '../settings/mask-manifest-flags.js';
 import * as sceneSettings from '../settings/scene-settings.js';
 import { debugLoadingProfiler } from '../core/debug-loading-profiler.js';
 
@@ -683,7 +688,8 @@ export class EffectStackUI {
 
   async _buildTileRows(tiles, maskCompositeInfo) {
     const registry = getEffectMaskRegistry();
-    const maskIds = Object.keys(registry);
+    const maskIds = collectEnabledMaskIds(canvas?.scene);
+    const maskProbeCacheKey = `${canvas?.scene?.id || 'scene'}:${maskIds.slice().sort().join(',')}`;
 
     const results = [];
 
@@ -830,19 +836,27 @@ export class EffectStackUI {
     ));
 
     for (const bp of basePaths) {
-      if (this._bundleMaskCache.has(bp)) continue;
+      const rowCacheKey = `${maskProbeCacheKey}::${bp}`;
+      if (this._bundleMaskCache.has(rowCacheKey)) continue;
       const __dlp = debugLoadingProfiler;
       const __bpLabel = bp.split('/').pop() || bp;
-      if (__dlp.debugMode) __dlp.begin(`es.loadBundle[${__bpLabel}]`, 'finalize');
+      if (__dlp.debugMode) __dlp.begin(`es.tileMaskListing[${__bpLabel}]`, 'finalize');
       try {
-        const res = await loadAssetBundle(bp, null, { skipBaseTexture: true, suppressProbeErrors: true });
-        const masks = res?.bundle?.masks || [];
-        const foundIds = new Set(masks.map((m) => m?.id).filter(Boolean));
-        this._bundleMaskCache.set(bp, { foundIds, loadError: null });
+        let foundIds = new Set();
+        let probeKnown = false;
+        if (isGmLike()) {
+          const files = await discoverMaskDirectoryFiles(bp);
+          if (files?.length) {
+            const byId = resolveMaskPathsFromListing(files, bp, maskIds);
+            foundIds = new Set(Object.keys(byId));
+            probeKnown = true;
+          }
+        }
+        this._bundleMaskCache.set(rowCacheKey, { foundIds, loadError: null, probeKnown });
       } catch (e) {
-        this._bundleMaskCache.set(bp, { foundIds: new Set(), loadError: e });
+        this._bundleMaskCache.set(rowCacheKey, { foundIds: new Set(), loadError: e, probeKnown: false });
       }
-      if (__dlp.debugMode) __dlp.end(`es.loadBundle[${__bpLabel}]`);
+      if (__dlp.debugMode) __dlp.end(`es.tileMaskListing[${__bpLabel}]`);
     }
 
     const query = String(this._tileFilterState.query || '').trim().toLowerCase();
@@ -889,12 +903,15 @@ export class EffectStackUI {
       let found = [];
       let missing = [];
       let loadError = null;
+      let probeKnownForRow = false;
 
       if (basePath) {
-        const cached = this._bundleMaskCache.get(basePath) || null;
+        const rowCacheKey = `${maskProbeCacheKey}::${basePath}`;
+        const cached = this._bundleMaskCache.get(rowCacheKey) || null;
         const foundIds = cached?.foundIds || null;
+        probeKnownForRow = cached?.probeKnown === true;
         loadError = cached?.loadError || null;
-        if (foundIds) {
+        if (foundIds && probeKnownForRow) {
           for (const id of maskIds) {
             if (foundIds.has(id)) found.push(id);
             else missing.push(id);
@@ -936,7 +953,7 @@ export class EffectStackUI {
       if (!cloudShadowsEnabled) chips.push('noCloudShadow');
       if (!cloudTopsEnabled) chips.push('noCloudTop');
 
-      const issues = !!loadError || (missing.length > 0);
+      const issues = !!loadError || (probeKnownForRow && missing.length > 0);
       const matchQuery = !query || (
         title.toLowerCase().includes(query) ||
         basePath.toLowerCase().includes(query) ||

--- a/scripts/utils/console-helpers.js
+++ b/scripts/utils/console-helpers.js
@@ -7,6 +7,9 @@
 import { createLogger } from '../core/log.js';
 import { globalProfiler } from '../core/profiler.js';
 import { globalLoadingProfiler } from '../core/loading-profiler.js';
+import { probeMaskFile } from '../assets/loader.js';
+import { tileHasLevelsRange, readTileLevelsFlags } from '../foundry/levels-scene-flags.js';
+import { isTileOverhead } from '../scene/tile-manager.js';
 
 const log = createLogger('ConsoleHelpers');
 
@@ -56,6 +59,77 @@ function _collectContinuousCandidates(floorCompositor) {
     lensGrainAmount: _toFinite(floorCompositor?._lensEffect?.params?.grainAmount),
     lensGrainSpeed: _toFinite(floorCompositor?._lensEffect?.params?.grainSpeed),
   };
+}
+
+/** Same rules as GpuSceneMaskCompositor._isTileInLevelBand (diagnostics only). */
+function _isTileInLevelBandDiagnostic(tileDoc, levelContext) {
+  const bandBottom = Number(levelContext?.bottom);
+  const bandTop = Number(levelContext?.top);
+  if (!Number.isFinite(bandBottom) || !Number.isFinite(bandTop)) return true;
+
+  if (tileHasLevelsRange(tileDoc)) {
+    const flags = readTileLevelsFlags(tileDoc);
+    const tileBottom = Number(flags.rangeBottom);
+    const tileTop = Number(flags.rangeTop);
+    if (Number.isFinite(tileBottom) && Number.isFinite(tileTop)) {
+      return !(tileTop <= bandBottom || tileBottom >= bandTop);
+    }
+    if (Number.isFinite(tileBottom)) {
+      return tileBottom >= bandBottom && tileBottom < bandTop;
+    }
+  }
+
+  const elev = Number(tileDoc?.elevation);
+  if (Number.isFinite(elev)) return elev >= bandBottom && elev < bandTop;
+  return true;
+}
+
+function _extractBasePathDiagnostic(src) {
+  const s = String(src || '').trim();
+  const lastDot = s.lastIndexOf('.');
+  return lastDot > 0 ? s.substring(0, lastDot) : s;
+}
+
+function _texProof(tex) {
+  if (!tex) return null;
+  return {
+    uuid: tex.uuid ?? null,
+    flipY: tex.flipY,
+    w: tex.image?.width ?? null,
+    h: tex.image?.height ?? null,
+    name: tex.name ?? null,
+  };
+}
+
+function _collectTilesForLevelBand(scene, levelContext) {
+  const out = [];
+  if (!scene) return out;
+  let tiles = scene.tiles ?? null;
+  if (!tiles) return out;
+  const tileIter = Array.isArray(tiles)
+    ? tiles
+    : (Array.isArray(tiles?.contents) ? tiles.contents : (tiles?.values?.() ?? []));
+  const bandBottom = Number(levelContext?.bottom);
+  const bandTop = Number(levelContext?.top);
+  const hasLevelFilter = Number.isFinite(bandBottom) && Number.isFinite(bandTop);
+
+  for (const tileDoc of tileIter) {
+    if (!tileDoc) continue;
+    const src = tileDoc?.texture?.src;
+    if (typeof src !== 'string' || src.trim().length === 0) continue;
+    if (tileDoc.hidden) continue;
+    try { if (tileDoc.getFlag?.('map-shine-advanced', 'bypassEffects')) continue; } catch (_) {}
+    if (hasLevelFilter) {
+      try { if (!_isTileInLevelBandDiagnostic(tileDoc, levelContext)) continue; } catch (_) {}
+    } else {
+      try { if (isTileOverhead(tileDoc)) continue; } catch (_) {}
+    }
+    const w = Number.isFinite(tileDoc?.width) ? tileDoc.width : 0;
+    const h = Number.isFinite(tileDoc?.height) ? tileDoc.height : 0;
+    if (!w || !h) continue;
+    out.push(tileDoc);
+  }
+  return out;
 }
 
 function _buildWindowedPassRows(currentRaw, prevRaw) {
@@ -1250,6 +1324,180 @@ export const consoleHelpers = {
   },
 
   /**
+   * Proof-oriented report: disk probe vs TileManager cache vs GpuSceneMaskCompositor
+   * for `_Outdoors` (and specular) on each level band. Copy the logged JSON.
+   *
+   * Usage:
+   *   await MapShine.debug.diagnoseUpperFloorOutdoorsProof()
+   *   copy(await MapShine.debug.diagnoseUpperFloorOutdoorsProof()) // DevTools
+   *
+   * @returns {Promise<object>}
+   */
+  async diagnoseUpperFloorOutdoorsProof() {
+    const ms = window.MapShine;
+    const scene = typeof canvas !== 'undefined' ? canvas?.scene : null;
+    const compositor = ms?.sceneComposer?._sceneMaskCompositor ?? null;
+    const tm = ms?.tileManager ?? null;
+    const reg = ms?.effectMaskRegistry ?? null;
+    const specEff = ms?.specularEffect ?? ms?.effectComposer?.effects?.get?.('specular') ?? null;
+    const floorStack = ms?.floorStack ?? null;
+    const floors = floorStack?.getFloors?.() ?? [];
+
+    const report = {
+      capturedAt: new Date().toISOString(),
+      sceneId: scene?.id ?? null,
+      activeLevelContext: ms?.activeLevelContext ?? null,
+      sceneComposer_lastMaskBasePath: ms?.sceneComposer?._lastMaskBasePath ?? null,
+      compositor_activeFloorKey: compositor?._activeFloorKey ?? null,
+      compositor_activeFloorBasePath: compositor?._activeFloorBasePath ?? null,
+      tileManager_vramMb: tm
+        ? (tm._tileEffectMaskVramBytes ?? 0) / (1024 * 1024)
+        : null,
+      tileManager_vramBudgetMb: tm?.effectMaskVramBudget != null
+        ? tm.effectMaskVramBudget / (1024 * 1024)
+        : null,
+      registry_outdoorsSlot: null,
+      specularEffect: {
+        outdoorsMask: _texProof(specEff?.outdoorsMask),
+        specularMask: _texProof(specEff?.specularMask),
+        uSpecularMap: _texProof(specEff?.material?.uniforms?.uSpecularMap?.value),
+      },
+      bands: {},
+    };
+
+    try {
+      const slot = reg?.getSlot?.('outdoors');
+      if (slot) {
+        report.registry_outdoorsSlot = {
+          floorKey: slot.floorKey ?? null,
+          source: slot.source ?? null,
+          texture: _texProof(slot.texture),
+        };
+      }
+    } catch (_) {}
+
+    for (const f of floors) {
+      const key = f?.compositorKey != null ? String(f.compositorKey) : null;
+      if (!key) continue;
+      const parts = key.split(':').map(Number);
+      const bottom = parts[0];
+      const top = parts[1];
+      const ctx = { bottom, top };
+      const bandBottom = Number(bottom);
+      const isUpper = Number.isFinite(bandBottom) && bandBottom > 0;
+
+      const meta = compositor?._floorMeta?.get(key) ?? null;
+      const masks = meta?.masks ?? [];
+      const outdoorsEntry = masks.find((m) => (m?.id ?? m?.type) === 'outdoors');
+      const specularEntry = masks.find((m) => (m?.id ?? m?.type) === 'specular');
+      const rtMap = compositor?._floorCache?.get(key);
+      const rtTypes = rtMap ? [...rtMap.keys()] : [];
+
+      const bandReport = {
+        floorIndex: f.index,
+        elevationMin: f.elevationMin,
+        elevationMax: f.elevationMax,
+        isUpperBand: isUpper,
+        compositor_getFloorTexture: {
+          outdoors: _texProof(compositor?.getFloorTexture?.(key, 'outdoors')),
+          specular: _texProof(compositor?.getFloorTexture?.(key, 'specular')),
+        },
+        compositor_floorCache_maskTypes: rtTypes,
+        compositor_floorMeta_maskTypes: masks.map((m) => m?.id ?? m?.type).filter(Boolean),
+        compositor_floorMeta_outdoors: {
+          hasMetaEntry: !!outdoorsEntry,
+          texture: _texProof(outdoorsEntry?.texture),
+        },
+        compositor_floorMeta_specular: {
+          hasMetaEntry: !!specularEntry,
+          texture: _texProof(specularEntry?.texture),
+        },
+        tiles: [],
+      };
+
+      const tileDocs = _collectTilesForLevelBand(scene, ctx);
+      for (const tileDoc of tileDocs) {
+        const tid = tileDoc?.id ?? '';
+        const src = typeof tileDoc?.texture?.src === 'string' ? tileDoc.texture.src.trim() : '';
+        const basePath = _extractBasePathDiagnostic(src);
+        const cached = tm?._tileEffectMasks?.get(tid);
+        let cacheKeys = null;
+        let cacheNote = null;
+        if (cached instanceof Map) {
+          if (cached.size === 0) cacheNote = 'EMPTY_MAP_poison';
+          cacheKeys = [...cached.keys()];
+        } else if (tm && tid) {
+          cacheNote = 'not_in_cache_yet';
+        }
+
+        let loaded = null;
+        let loadError = null;
+        if (tm?.loadAllTileMasks) {
+          try {
+            loaded = await tm.loadAllTileMasks(tileDoc);
+          } catch (e) {
+            loadError = String(e?.message || e);
+          }
+        }
+        const afterKeys = loaded instanceof Map ? [...loaded.keys()] : null;
+        const outdoorsLoaded = loaded?.get?.('outdoors') ?? null;
+        const specLoaded = loaded?.get?.('specular') ?? null;
+
+        let probeOutdoors = null;
+        let probeSpecular = null;
+        if (basePath) {
+          try {
+            probeOutdoors = await probeMaskFile(basePath, '_Outdoors', { suppressProbeErrors: true });
+          } catch (_) { probeOutdoors = null; }
+          try {
+            probeSpecular = await probeMaskFile(basePath, '_Specular', { suppressProbeErrors: true });
+          } catch (_) { probeSpecular = null; }
+        }
+
+        bandReport.tiles.push({
+          tileIdSuffix: tid.length > 8 ? tid.slice(-8) : tid,
+          textureSrc: src || null,
+          basePath: basePath || null,
+          cacheBeforeLoad_keys: cacheKeys,
+          cacheBeforeLoad_note: cacheNote,
+          afterLoadAllTileMasks_keys: afterKeys,
+          loadAllTileMasks_error: loadError,
+          loaded_outdoors_url: outdoorsLoaded?.url ?? null,
+          loaded_outdoors_texture: _texProof(outdoorsLoaded?.texture),
+          loaded_specular_url: specLoaded?.url ?? null,
+          loaded_specular_texture: _texProof(specLoaded?.texture),
+          probeMaskFile_diskPath_outdoors: probeOutdoors?.path ?? null,
+          probeMaskFile_diskPath_specular: probeSpecular?.path ?? null,
+          interpretation_outdoors: (() => {
+            const diskO = !!probeOutdoors?.path;
+            const gotO = !!(outdoorsLoaded?.texture);
+            if (diskO && !gotO) return 'FILE_LISTED_BUT_loadAllTileMasks_DID_NOT_LOAD_outdoors';
+            if (!diskO && !gotO) return 'no_outdoors_file_found_for_basePath';
+            if (!diskO && gotO) return 'loaded_without_probe_hit_unusual';
+            return 'outdoors_ok';
+          })(),
+          interpretation_specular: (() => {
+            const diskS = !!probeSpecular?.path;
+            const gotS = !!(specLoaded?.texture);
+            if (diskS && !gotS) return 'FILE_LISTED_BUT_loadAllTileMasks_DID_NOT_LOAD_specular';
+            if (!diskS && !gotS) return 'no_specular_file_found_for_basePath';
+            if (!diskS && gotS) return 'loaded_without_probe_hit_unusual';
+            return 'specular_ok';
+          })(),
+        });
+      }
+
+      report.bands[key] = bandReport;
+    }
+
+    const json = JSON.stringify(report, null, 2);
+    console.group('MapShine diagnoseUpperFloorOutdoorsProof (copy JSON below)');
+    console.log(json);
+    console.groupEnd();
+    return report;
+  },
+
+  /**
    * Quick mask binding snapshot ->-> shows what texture each floor-scoped
    * effect currently has bound for each mask type.
    * Usage: MapShine.debug.diagnoseFloorMasks()
@@ -1348,6 +1596,7 @@ Available commands (access via MapShine.debug):
 
   .diagnoseFloorRendering() - Comprehensive floor rendering report
   .diagnoseFloorDeepdive()  - Deep-dive: _floorCache RTs, uniform snapshot, tile overlays, _tileEffectMasks
+  .diagnoseUpperFloorOutdoorsProof() - JSON: disk probe vs tile mask load vs compositor (async)
   .diagnoseFloorMasks()     - Quick snapshot of per-effect mask bindings
   .alphaIsolationStatus()   - Read active alpha/isolation debug flags
   .alphaIsolationSet(obj)   - Merge alpha/isolation debug flags
@@ -1368,6 +1617,9 @@ Floor debugging examples:
 
   // Quick mask binding snapshot
   MapShine.debug.diagnoseFloorMasks()
+
+  // Upper-floor _Outdoors / specular load proof (paste JSON to devs)
+  copy(await MapShine.debug.diagnoseUpperFloorOutdoorsProof())
 
 Other examples:
 


### PR DESCRIPTION
Draft PR for \cursor/building-shadows-multi-floor-outdoors-roof\ into \master\.

Includes multi-floor building shadow work, premultiplied tree/bush mask output (fringe fix), GPU mask compositor and related wiring (loader, tile-manager, composer, effect-stack, flags, console helpers).